### PR TITLE
dependencies: add contexthub as dependency

### DIFF
--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -1,6 +1,11 @@
 [
   {
-    "repository": "android_kernel_google_marlin",
+    "remote":      "aosp",
+    "repository":  "device/google/contexthub",
+    "target_path": "device/google/contexthub"
+  },
+  {
+    "repository":  "android_kernel_google_marlin",
     "target_path": "kernel/google/marlin"
   }
 ]


### PR DESCRIPTION
Upstream does not include the contexthub repo,
which is required for Google devices.[1]

Add it to lineage.dependencies to automatically
sync the repo for marlin/sailfish.

[1] - https://github.com/Halium/android/blob/8e43a9652d0aecc3a5cb462362aa8a1efd44e647/default.xml#L87